### PR TITLE
Added develop script and enforce node version

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,9 @@
 /**
+ * Check Node Version FIRST
+ */
+require('node-version-checker')
+
+/**
  * Module dependencies.
  */
 var express = require('express')

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "type": "git",
     "url": "https://github.com/sfbrigade/brigadehub.git"
   },
+  "engines": {
+    "node": ">=4 <5"
+  },
   "scripts": {
     "start": "node app.js",
     "pretest": "standard",
@@ -41,6 +44,7 @@
     "mongoose": "^4.3.5",
     "morgan": "^1.6.1",
     "node-sass-middleware": "^0.9.7",
+    "node-version-checker": "^1.0.6",
     "nodemailer": "^2.0.0",
     "passport": "0.3.2",
     "passport-github": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "node app.js",
     "pretest": "standard",
     "test": "istanbul cover _mocha -- --reporter spec --timeout 5000",
+    "db:clear": "./scripts/database-clear",
     "develop": "nodemon app.js"
   },
   "dependencies": {
@@ -64,6 +65,7 @@
     "blessed": "^0.1.81",
     "chai": "^3.4.1",
     "mocha": "^2.3.4",
+    "mongodb": "^2.1.7",
     "multiline": "^1.0.2",
     "nodemon": "^1.9.1",
     "supertest": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "start": "node app.js",
     "pretest": "standard",
-    "test": "istanbul cover _mocha -- --reporter spec --timeout 5000"
+    "test": "istanbul cover _mocha -- --reporter spec --timeout 5000",
+    "develop": "nodemon app.js"
   },
   "dependencies": {
     "async": "^1.5.2",
@@ -60,6 +61,7 @@
     "chai": "^3.4.1",
     "mocha": "^2.3.4",
     "multiline": "^1.0.2",
+    "nodemon": "^1.9.1",
     "supertest": "^1.1.0"
   },
   "license": "ISC"

--- a/scripts/database-clear
+++ b/scripts/database-clear
@@ -1,0 +1,38 @@
+#! /usr/bin/env node
+
+var MongoClient = require('mongodb').MongoClient
+var assert = require('assert')
+var dotenv = require('dotenv')
+
+var path = require('path')
+var fs = require('fs')
+
+/**
+ * Load environment variables from .env file, where API keys and passwords are configured.
+ *
+ * Default path: .env
+ */
+try {
+  var stats = fs.lstatSync(path.resolve(__dirname, '../.env'))
+  if (stats.isFile()) {
+    dotenv.load({ path: path.resolve(__dirname, '../.env') })
+  } else {
+    throw new Error('.env is not a file!')
+  }
+} catch (e) {
+  console.warn(e)
+  console.warn('.env file not found. Defaulting to sample. Please copy .env.example to .env and populate with your own credentials.')
+  dotenv.load({ path: path.resolve(__dirname, '../.env.example') })
+}
+
+// Connection URL
+var url = process.env.MONGODB
+
+// Use connect method to connect to the Server
+MongoClient.connect(url, function (err, db) {
+  assert.equal(null, err)
+  console.log('Connected correctly to server', url)
+  db.dropDatabase()
+  console.log('Dropped database successfully', url)
+  db.close()
+})


### PR DESCRIPTION
see #59 for node version discussion

@sfbrigade/project-brigadehub this will effect how you can run the application locally. Please make sure you have Node version 4.x.x available for development locally after this is merged. (Best way would be via [NVM](https://github.com/creationix/nvm))

Added commands:
- `npm start` - runs the app with node
- `npm run develop` - runs the app with nodemon
- `npm run db:clear` - clears the database (useful for before we put in migrations)
