### PR TITLE
Dynamic keyword list on Projects index

### DIFF
--- a/controllers/projects.js
+++ b/controllers/projects.js
@@ -13,8 +13,8 @@ module.exports = {
     Projects.find({brigade: res.locals.brigade.slug}, function (err, foundProjects) {
       if (err) console.error(err)
       var allKeywords = []
-      foundProjects.forEach(function(project) {
-        project.keywords.forEach(function(keyword) {
+      foundProjects.forEach(function (project) {
+        project.keywords.forEach(function (keyword) {
           if (allKeywords.indexOf(keyword) < 0) {
             allKeywords.push(keyword)
           }

--- a/controllers/projects.js
+++ b/controllers/projects.js
@@ -12,10 +12,19 @@ module.exports = {
   getProjects: function (req, res) {
     Projects.find({brigade: res.locals.brigade.slug}, function (err, foundProjects) {
       if (err) console.error(err)
+      var allKeywords = []
+      foundProjects.forEach(function(project) {
+        project.keywords.forEach(function(keyword) {
+          if (allKeywords.indexOf(keyword) < 0) {
+            allKeywords.push(keyword)
+          }
+        })
+      })
       res.render(res.locals.brigade.theme.slug + '/views/projects/index', {
         title: 'Projects',
         brigade: res.locals.brigade,
-        projects: foundProjects
+        projects: foundProjects,
+        keywords: allKeywords.sort()
       })
     })
   },

--- a/themes/atl/views/projects/index.jade
+++ b/themes/atl/views/projects/index.jade
@@ -19,12 +19,7 @@ block content
       .col-sm-3.sidebar
         //parent list
         ul
-          mixin sidebarItem('Project status',['Development','Public test','Official / running'])
-          mixin sidebarItem('Dedicated for',['Civil society organizations','Cities','Watchdogs'])
-          mixin sidebarItem('Development status',['active','Suspended'])
-          mixin sidebarItem('Join as',['backend developer','frontend developer','designer','editorial staff'])
-          mixin sidebarItem('Developed locally in',['San Francisco'])
-          mixin sidebarItem('Technologies',['Android','AngularJS','Django','iOS','Javascript'])
+          mixin sidebarItem('Keywords',keywords)
       //Add projects    
       .col-sm-9
         .row


### PR DESCRIPTION
Starts on (and technically could be closing) #108. I manually edited the `keywords` properties locally in Robomongo to add `keywords`.

Still needs some more work to actually function:

1 -  Filtering list of Projects by selected tag. Not sure what the best approach is here, but 2 ideas that come to mind for what happens when a user clicks on a keyword link:
    \* Hide all projects which don't contain the selected `keyword`
    \* Reload the page, filtering the list

Also brings up the question of how removing the filter should work.

2 - Getting keywords into the `codeforexample` data -- discussed this with @therebelrobot in person last week and it sounded like we need to some `civic.json` setup

Not sure if this ready for merge yet, but opening for review / discussion (or merge, if it looks ok)

![screen shot 2016-03-27 at 6 08 16 pm](https://cloud.githubusercontent.com/assets/1236811/14068957/f4e8ab0e-f446-11e5-9279-61960846ec76.png)
