### PR TITLE
Fix typo in `config/passport.js`

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -117,7 +117,7 @@ passport.use(new GitHubStrategy({
 }))
 
 /**
- * Sign in with GitHub.
+ * Link Meetup account
  */
 passport.use(new MeetupStrategy({
   consumerKey: process.env.MEETUP_KEY,


### PR DESCRIPTION
The code about linking your Meetup account had a comment above it that said it was about signing in with GitHub. This fixes the comment.
