### PR TITLE
Removing verify so peeps can commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
   "license": "ISC",
   "pre-commit": [
     "lint",
-    "validate",
     "test"
   ]
 }


### PR DESCRIPTION
### Description
#### Fixed

This PR repairs the precommit hook so that it no longer runs verify, which is making it so people need to install jshint to get their stuff.  It may be the case now that verify is no longer required in package.json
- [x] This Pull Request template has actually been modified with relevant data ;)
- [x] This PR passes Linting tests (see below)
- [x] This PR does not contain merge conflicts with `edge` (see below)
- [x] This PR does not contain:
  - Additional Dependencies in `package.json` that are not used
  - Frontend JS in Jade templates (unless absolutely necessary)
  - Any functionality which depends on frontend JS being enabled (unless already discussed as a team)
