### PR TITLE
Custom nav links, elevating github auths

### DIFF
--- a/app.js
+++ b/app.js
@@ -72,9 +72,10 @@ mongoose.connection.on('error', function () {
 })
 
 /**
- * Check Brigade Settings in db
+ * Check Model Settings in db
  */
 var Brigade = require('./models/Brigade')
+var User = require('./models/Users')
 
 /**
  * Express configuration.
@@ -129,7 +130,25 @@ app.use(lusca({
   xssProtection: true
 }))
 app.use(function (req, res, next) {
+  // check postAuthLink and see if going to auth callback
+  if (req.user && req.user.postAuthLink.length) {
+    if (!(/auth\/github\/callback/i.test(req.path))) {
+      return User.findById(req.user.id, function (err, user) {
+        if (err) console.error(err)
+        user.postAuthLink = req.user.postAuthLink = ''
+        user.save(function (err) {
+          if (err) console.error(err)
+          res.locals.user = req.user
+          next()
+        })
+      })
+    }
+  }
   res.locals.user = req.user
+  next()
+})
+app.use(function (req, res, next) {
+  req.previousURL = req.header('Referer') || '/'
   next()
 })
 app.use(function (req, res, next) {
@@ -145,13 +164,25 @@ app.use(function (req, res, next) {
 app.get('/', homeCtrl.index)
 app.get('/login', usersCtrl.getLogin)
 app.post('/login', usersCtrl.postLogin)
-app.get('/login/edit', passportConf.isAuthenticated, usersCtrl.getLoginEdit)
-app.post('/login/edit', passportConf.isAuthenticated, usersCtrl.postLoginEdit)
+app.get('/login/edit',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  usersCtrl.getLoginEdit)
+app.post('/login/edit',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  usersCtrl.postLoginEdit)
 app.get('/logout', usersCtrl.getLogout)
 app.get('/contact', contactCtrl.getContact)
 app.post('/contact', contactCtrl.postContact)
-app.get('/contact/edit', passportConf.isAuthenticated, contactCtrl.getContactEdit)
-app.post('/contact/message/new', passportConf.isAuthenticated, contactCtrl.postContactMessage)
+app.get('/contact/edit',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  contactCtrl.getContactEdit)
+app.post('/contact/message/new',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  contactCtrl.postContactMessage)
 
 /**
  * Meta Routes
@@ -161,66 +192,194 @@ app.get('/account', passportConf.isAuthenticated, usersCtrl.getAccount)
 app.post('/account/profile', passportConf.isAuthenticated, usersCtrl.postUpdateProfile)
 app.post('/account/delete', passportConf.isAuthenticated, usersCtrl.postDeleteAccount)
 
-app.get('/brigade', passportConf.isAuthenticated, brigadeCtrl.getBrigade)
-app.post('/brigade', passportConf.isAuthenticated, brigadeCtrl.postBrigade)
+app.get('/brigade',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  brigadeCtrl.getBrigade)
+app.post('/brigade',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  brigadeCtrl.postBrigade)
 
 /**
  * Project routes.
  */
 app.get('/projects', projectsCtrl.getProjects)
-app.get('/projects/manage', passportConf.isAuthenticated, projectsCtrl.getProjectsManage)
-app.post('/projects/manage', passportConf.isAuthenticated, projectsCtrl.postProjectsManage)
-app.post('/projects/sync', passportConf.isAuthenticated, projectsCtrl.postProjectsSync)
+app.get('/projects/manage',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['lead', 'core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo']),
+  projectsCtrl.getProjectsManage)
+app.post('/projects/manage',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['lead', 'core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo']),
+  projectsCtrl.postProjectsManage)
+app.post('/projects/sync',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  projectsCtrl.postProjectsSync)
 app.get('/projects/new', passportConf.isAuthenticated, projectsCtrl.getProjectsNew)
 app.post('/projects/new', passportConf.isAuthenticated, projectsCtrl.postProjectsNew)
 app.get('/projects/:projectId', projectsCtrl.getProjectsID)
-app.post('/projects/:projectId', passportConf.isAuthenticated, projectsCtrl.postProjectsIDSettings)
-app.get('/projects/:projectId/settings', passportConf.isAuthenticated, projectsCtrl.getProjectsIDSettings)
-app.post('/projects/:projectId/sync', passportConf.isAuthenticated, projectsCtrl.postProjectsIDSync)
+app.post('/projects/:projectId',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['lead', 'core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo']),
+  projectsCtrl.postProjectsIDSettings)
+app.get('/projects/:projectId/settings',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['lead', 'core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo']),
+  projectsCtrl.getProjectsIDSettings)
+app.post('/projects/:projectId/sync',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['lead', 'core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo']),
+  projectsCtrl.postProjectsIDSync)
 
 /**
  * Events routes.
  */
 app.get('/events', eventsCtrl.getEvents)
-app.get('/events/manage', passportConf.isAuthenticated, eventsCtrl.getEventsManage)
-app.post('/events/manage', passportConf.isAuthenticated, eventsCtrl.postEventsManage)
-app.post('/events/sync', passportConf.isAuthenticated, eventsCtrl.postEventsSync)
-app.get('/events/new', passportConf.isAuthenticated, eventsCtrl.getEventsNew)
-app.post('/events/new', passportConf.isAuthenticated, eventsCtrl.postEventsNew)
-app.post('/events/delete', passportConf.isAuthenticated, eventsCtrl.postDeleteAllEvents)
+app.get('/events/manage',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  eventsCtrl.getEventsManage)
+app.post('/events/manage',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  eventsCtrl.postEventsManage)
+app.post('/events/sync',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  eventsCtrl.postEventsSync)
+app.get('/events/new',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  eventsCtrl.getEventsNew)
+app.post('/events/new',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  eventsCtrl.postEventsNew)
+app.post('/events/delete',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  eventsCtrl.postDeleteAllEvents)
 app.get('/events/:eventId', eventsCtrl.getEventsID)
-app.post('/events/:eventId', passportConf.isAuthenticated, eventsCtrl.postEventsIDSettings)
-app.get('/events/:eventId/settings', passportConf.isAuthenticated, eventsCtrl.getEventsIDSettings)
-app.post('/events/:eventId/sync', passportConf.isAuthenticated, eventsCtrl.postEventsIDSync)
-app.post('/events/:eventId/delete', passportConf.isAuthenticated, eventsCtrl.postDeleteEvent)
+app.post('/events/:eventId',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  eventsCtrl.postEventsIDSettings)
+app.get('/events/:eventId/settings',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  eventsCtrl.getEventsIDSettings)
+app.post('/events/:eventId/sync',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  eventsCtrl.postEventsIDSync)
+app.post('/events/:eventId/delete',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  eventsCtrl.postDeleteEvent)
 
 /**
  * Blog routes.
  */
 app.get('/blog', blogCtrl.getBlog)
-app.get('/blog/manage', passportConf.isAuthenticated, blogCtrl.getBlogManage)
-app.post('/blog/manage', passportConf.isAuthenticated, blogCtrl.postBlogManage)
-app.post('/blog/sync', passportConf.isAuthenticated, blogCtrl.postBlogSync)
-app.get('/blog/new', passportConf.isAuthenticated, blogCtrl.getBlogNew)
-app.post('/blog/new', passportConf.isAuthenticated, blogCtrl.postBlogNew)
+app.get('/blog/manage',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['blog', 'lead', 'core', 'superAdmin']),
+  blogCtrl.getBlogManage)
+app.post('/blog/manage',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['blog', 'lead', 'core', 'superAdmin']),
+  blogCtrl.postBlogManage)
+app.post('/blog/sync',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['blog', 'lead', 'core', 'superAdmin']),
+  blogCtrl.postBlogSync)
+app.get('/blog/new',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['blog', 'lead', 'core', 'superAdmin']),
+  blogCtrl.getBlogNew)
+app.post('/blog/new',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['blog', 'lead', 'core', 'superAdmin']),
+  blogCtrl.postBlogNew)
 app.get('/blog/:blogId', blogCtrl.getBlogID)
-app.post('/blog/:blogId', passportConf.isAuthenticated, blogCtrl.postBlogIDEdit)
-app.get('/blog/:blogId/edit', passportConf.isAuthenticated, blogCtrl.getBlogIDEdit)
-app.post('/blog/:blogId/sync', passportConf.isAuthenticated, blogCtrl.postBlogIDSync)
+app.post('/blog/:blogId',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['blog', 'lead', 'core', 'superAdmin']),
+  blogCtrl.postBlogIDEdit)
+app.get('/blog/:blogId/edit',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['blog', 'lead', 'core', 'superAdmin']),
+  blogCtrl.getBlogIDEdit)
+app.post('/blog/:blogId/sync',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['blog', 'lead', 'core', 'superAdmin']),
+  blogCtrl.postBlogIDSync)
 
 /**
  * Users routes.
  */
 app.get('/users', usersCtrl.getUsers)
-app.get('/users/manage', passportConf.isAuthenticated, usersCtrl.getUsersManage)
-app.post('/users/manage', passportConf.isAuthenticated, usersCtrl.postUsersManage)
-app.post('/users/sync', passportConf.isAuthenticated, usersCtrl.postUsersSync)
-app.get('/users/new', passportConf.isAuthenticated, usersCtrl.getUsersNew)
-app.post('/users/new', passportConf.isAuthenticated, usersCtrl.postUsersNew)
+app.get('/users/manage',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  usersCtrl.getUsersManage)
+app.post('/users/manage',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  usersCtrl.postUsersManage)
+app.post('/users/sync',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  usersCtrl.postUsersSync)
+app.get('/users/new',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  usersCtrl.getUsersNew)
+app.post('/users/new',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  usersCtrl.postUsersNew)
 app.get('/users/:userId', usersCtrl.getUsersID)
-app.post('/users/:userId', passportConf.isAuthenticated, usersCtrl.postUsersIDSettings)
-app.get('/users/:userId/settings', passportConf.isAuthenticated, usersCtrl.getUsersIDSettings)
-app.post('/users/:userId/sync', passportConf.isAuthenticated, usersCtrl.postUsersIDSync)
+app.post('/users/:userId',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  usersCtrl.postUsersIDSettings)
+app.get('/users/:userId/settings',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  usersCtrl.getUsersIDSettings)
+app.post('/users/:userId/sync',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo', 'admin:org', 'admin:repo_hook', 'admin:org_hook']),
+  usersCtrl.postUsersIDSync)
 
 /**
  * OAuth authentication routes. (Sign in)
@@ -228,18 +387,13 @@ app.post('/users/:userId/sync', passportConf.isAuthenticated, usersCtrl.postUser
 app.get('/auth/github', passport.authenticate('github', {
   scope: [
     'user',
-    'repo',
-    'repo_deployment',
-    'repo:status',
-    'admin:repo_hook',
-    'admin:org_hook',
-    'read:org',
-    'write:org',
-    'admin:org'
+    'public_repo'
   ]
 }))
+app.get('/auth/github/elevate', passportConf.elevateScope)
 app.get('/auth/github/callback', passport.authenticate('github', { failureRedirect: '/login' }), function (req, res) {
-  res.redirect(req.session.returnTo || '/')
+  console.log(req.user.postAuthLink)
+  res.redirect(req.user.postAuthLink.length ? req.user.postAuthLink : '/')
 })
 app.get('/auth/meetup', passport.authenticate('meetup', { scope: ['basic', 'rsvp'] }))
 app.get('/auth/meetup/callback', passport.authenticate('meetup', { failureRedirect: '/account' }), function (req, res) {

--- a/controllers/brigade.js
+++ b/controllers/brigade.js
@@ -56,12 +56,12 @@ exports.postBrigade = function (req, res, next) {
     } else if (req.body['theme-slug']) { // theme updated
       thisBrigade.theme.slug = req.body['theme-slug']
       thisBrigade.theme.logo = req.body.logo
-      thisBrigade.theme.show.title = req.body['show-title'] === 'on'
-      thisBrigade.theme.show.events = req.body['show-events'] === 'on'
-      thisBrigade.theme.show.projects = req.body['show-projects'] === 'on'
-      thisBrigade.theme.show.blog = req.body['show-blog'] === 'on'
-      thisBrigade.theme.show.about = req.body['show-about'] === 'on'
-      thisBrigade.theme.show.login = req.body['show-login'] === 'on'
+      thisBrigade.theme.page.title = req.body['show-title'] === 'on'
+      thisBrigade.theme.page.events = req.body['show-events'] === 'on'
+      thisBrigade.theme.page.projects = req.body['show-projects'] === 'on'
+      thisBrigade.theme.page.blog = req.body['show-blog'] === 'on'
+      thisBrigade.theme.page.about = req.body['show-about'] === 'on'
+      thisBrigade.theme.page.login = req.body['show-login'] === 'on'
     } else { // social media keys updated
       thisBrigade.auth.github.clientId = req.body['github-client-id']
       thisBrigade.auth.github.clientSecret = req.body['github-client-secret']

--- a/models/Brigade.js
+++ b/models/Brigade.js
@@ -17,13 +17,14 @@ var brigadeSchema = new mongoose.Schema({
   theme: {
     slug: String,
     logo: String,
-    show: {
+    page: {
       title: Boolean,
       events: Boolean,
       projects: Boolean,
       blog: Boolean,
       about: Boolean,
-      login: Boolean
+      login: Boolean,
+      external: Array
     }
   },
   copy: {

--- a/models/Users.js
+++ b/models/Users.js
@@ -17,6 +17,9 @@ var userSchema = new mongoose.Schema({
   /* password: String,*/
   github: String,
   tokens: Array,
+  scopes: Array,
+  requestingScopes: String,
+  postAuthLink: String,
   roles: {
     read: {type: Boolean, default: true},
     blog: {type: Boolean, default: false},

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
   "license": "ISC",
   "pre-commit": [
     "lint",
-    "validate",
     "test"
   ]
 }

--- a/seeds/development/Brigade.js
+++ b/seeds/development/Brigade.js
@@ -18,13 +18,20 @@ module.exports = function () {
     theme: {
       slug: 'atl',
       logo: '',
-      show: {
+      page: {
         title: true,
         events: true,
         projects: true,
         blog: true,
         about: true,
-        login: true
+        login: true,
+        external: [
+          {
+            name: 'External',
+            link: 'https://google.com',
+            target: '_blank'
+          }
+        ]
       }
     },
     copy: {

--- a/themes/atl/public/css/main.scss
+++ b/themes/atl/public/css/main.scss
@@ -23,6 +23,8 @@ body {
   padding-top: 110px;
 
   transition: padding-top $scroll-transition ease-in-out;
+
+  font-family: 'Source Sans Pro', 'Helvetica', 'Arial', sans-serif;
 }
 
 footer {
@@ -153,7 +155,7 @@ nav.navbar {
   .row.account {
 
     transition: height $scroll-transition ease-in-out, margin-bottom $scroll-transition ease-in-out;
-    
+
     img {
       transition: height $scroll-transition ease-in-out, margin-bottom $scroll-transition ease-in-out;
     }
@@ -183,7 +185,7 @@ nav.navbar {
   }
   .row.navigation {
     border-top: 1px solid rgba(0, 0, 0, 0.1);
-    
+
     .navbar-nav {
       padding-top: 9px;
     }
@@ -205,11 +207,11 @@ nav.navbar {
       padding-top: 9px;
     }
   }
-  
+
   .navbar-toggler {
     margin-top: 8px;
     float: right;
-    
+
     &:focus {
       outline:none;
     }

--- a/themes/atl/views/brigade.jade
+++ b/themes/atl/views/brigade.jade
@@ -58,45 +58,74 @@ block content
     h3 Theme Settings
   form.row.form-horizontal(action='/brigade', method='POST')
     input(type='hidden', name='_csrf', value=_csrf)
-    .form-group
+    .form-group.row
       label.col-sm-3.control-label(for='theme-slug') Theme
       .col-sm-7
         input.form-control(type='text', name='theme-slug', id='theme-slug', value='#{brigade.theme.slug}')
-    .form-group
+    .form-group.row
       label.col-sm-3.control-label(for='logo') Logo
       .col-sm-7
         input.form-control(type='text', name='logo', id='logo', value='#{brigade.theme.logo}')
       .col-sm-offset-3.col-sm-4
         img(src="#{brigade.theme.logo}", class='logo')
-    .form-group
+    .form-group.row
       label.col-sm-3.control-label Enabled Sections
       .col-sm-7
         .row
           .col-sm-4.checkbox
             label
-              input.title(id="show-title", name="show-title", type="checkbox", checked=(brigade.theme.show.title ? "checked" : undefined))
+              input.title(id="show-title", name="show-title", type="checkbox", checked=(brigade.theme.page.title ? "checked" : undefined))
               | Show Brigade Name
           .col-sm-4.checkbox
             label
-              input.events(id="show-events", name="show-events", type="checkbox", checked=(brigade.theme.show.events ? "checked" : undefined))
+              input.events(id="show-events", name="show-events", type="checkbox", checked=(brigade.theme.page.events ? "checked" : undefined))
               | Show Events Pages
           .col-sm-4.checkbox
             label
-              input.projects(id="show-projects", name="show-projects", type="checkbox", checked=(brigade.theme.show.projects ? "checked" : undefined))
+              input.projects(id="show-projects", name="show-projects", type="checkbox", checked=(brigade.theme.page.projects ? "checked" : undefined))
               | Show Projects Pages
         .row
           .col-sm-4.checkbox
             label
-              input.blog(id="show-blog", name="show-blog", type="checkbox", checked=(brigade.theme.show.blog ? "checked" : undefined))
+              input.blog(id="show-blog", name="show-blog", type="checkbox", checked=(brigade.theme.page.blog ? "checked" : undefined))
               | Show Blog Pages
           .col-sm-4.checkbox
             label
-              input.about(id="show-about", name="show-about", type="checkbox", checked=(brigade.theme.show.about ? "checked" : undefined))
+              input.about(id="show-about", name="show-about", type="checkbox", checked=(brigade.theme.page.about ? "checked" : undefined))
               | Show About Page
           .col-sm-4.checkbox
             label
-              input.login(id="show-login", name="show-login", type="checkbox", checked=(brigade.theme.show.login ? "checked" : undefined))
+              input.login(id="show-login", name="show-login", type="checkbox", checked=(brigade.theme.page.login ? "checked" : undefined))
               | Show Login Page
+    each external in brigade.theme.page.external
+      .row
+        hr
+        .form-group.col-sm-12
+          label.col-sm-3.control-label(for='external-link-name') External Link Name
+          .col-sm-7
+            input.form-control(type='text', name='external-link-name', id='external-link-name', value='#{external.name}')
+        .form-group.col-sm-12
+          label.col-sm-3.control-label(for='external-link') External Link
+          .col-sm-7
+            input.form-control(type='text', name='external-link', id='external-link', value='#{external.link}')
+        .form-group.col-sm-12
+          label.col-sm-3.control-label(for='external-link-target') External Link Target
+          .col-sm-7
+            input.form-control(type='text', name='external-link-target', id='external-link-target', value='#{external.target}')
+    .row
+      hr
+      .form-group.col-sm-12
+        label.col-sm-3.control-label(for='new-external-link-name') External Link Name
+        .col-sm-7
+          input.form-control(type='text', name='new-external-link-name', id='new-external-link-name', value='', placeholder='External Link Title')
+      .form-group.col-sm-12
+        label.col-sm-3.control-label(for='new-external-link') External Link
+        .col-sm-7
+          input.form-control(type='text', name='new-external-link', id='new-external-link', value='', placeholder='http://example.com')
+      .form-group.col-sm-12
+        label.col-sm-3.control-label(for='new-external-link-target') External Link Target
+        .col-sm-7
+          input.form-control(type='text', name='new-external-link-target', id='new-external-link-target', value='', placeholder='self or _blank')
     .form-group
       .col-sm-offset-3.col-sm-4
         button.btn.btn.btn-primary(type='submit')

--- a/themes/atl/views/layout.jade
+++ b/themes/atl/views/layout.jade
@@ -6,6 +6,7 @@ html
     meta(name='viewport', content='width=device-width, initial-scale=1.0')
     meta(name='csrf-token', content=_csrf)
     title #{title} - #{brigade.name}
+    link(href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,700,400italic,700italic,300,300italic', rel='stylesheet,' type='text/css')
     link(rel='stylesheet', href='https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/4.0.0-alpha.2/css/bootstrap.css')
     link(rel='stylesheet', href='https://cdnjs.cloudflare.com/ajax/libs/fullcalendar/2.6.0/fullcalendar.css')
     link(rel='stylesheet', href='/css/main.css')

--- a/themes/atl/views/partials/footer.jade
+++ b/themes/atl/views/partials/footer.jade
@@ -16,17 +16,21 @@ footer
       ul
         li#menu-item-385.menu-item.menu-item-type-post_type.menu-item-object-page.menu-item-385
           a(href='http://codeforpoland.org/')=brigade.name
-        if brigade.theme.show.events
+        if brigade.theme.page.events
           li
             a(href='/events') Events
-        if brigade.theme.show.projects
+        if brigade.theme.page.projects
           li
             a(href='/projects') Projects
-        if brigade.theme.show.blog
+        if brigade.theme.page.blog
           li
             a(href='/blog') Blog
-        if brigade.theme.show.about
+        each external in brigade.theme.page.external
+          li
+            a(href=external.link, target=external.target)=external.name
+        if brigade.theme.page.about
           li
             a(href='/contact') Contact
+            
         li.float.right
           a(href='https://github.com/sfbrigade/brigadehub') powered by brigadehub

--- a/themes/atl/views/partials/header.jade
+++ b/themes/atl/views/partials/header.jade
@@ -43,18 +43,18 @@ nav.navbar.navbar-light.bg-faded.navbar-fixed-top
         span= brigade.name
       .collapse.navbar-toggleable-xs#collapsingNavbar
         ul.nav.navbar-nav.pull-xs-right
-          if brigade.theme.show.events
+          if brigade.theme.page.events
             li.nav-item(class=title=='Events'?'active':undefined)
               a.nav-link(href='/events') Events
-          if brigade.theme.show.projects
+          if brigade.theme.page.projects
             li.nav-item(class=title=='Projects'?'active':undefined)
               a.nav-link(href='/projects') Projects
-          if brigade.theme.show.blog
+          if brigade.theme.page.blog
             li.nav-item(class=title=='Blog'?'active':undefined)
               a.nav-link(href='/blog') Blog
           each external in brigade.theme.page.external
             li.nav-item
               a.nav-link(href=external.link, target=external.target)=external.name
-          if brigade.theme.show.about
+          if brigade.theme.page.about
             li.nav-item(class=title=='Contact'?'active':undefined)
               a.nav-link(href='/contact') Contact

--- a/themes/atl/views/partials/header.jade
+++ b/themes/atl/views/partials/header.jade
@@ -4,7 +4,7 @@ nav.navbar.navbar-light.bg-faded.navbar-fixed-top
       a.navbar-brand(href='/')
         img(src='/logo.png')
       ul.nav.navbar-nav.pull-xs-right
-        if brigade.theme.show.login
+        if brigade.theme.page.login
           if !user
             li(class=title=='Login'?'active':undefined)
               a(href='/login') Login
@@ -41,15 +41,15 @@ nav.navbar.navbar-light.bg-faded.navbar-fixed-top
         img.brigade-logo(src='https://i.imgur.com/BoXEeve.png')
         span= brigade.name
       ul.nav.navbar-nav.pull-xs-right
-        if brigade.theme.show.events
+        if brigade.theme.page.events
           li.nav-item(class=title=='Events'?'active':undefined)
             a.nav-link(href='/events') Events
-        if brigade.theme.show.projects
+        if brigade.theme.page.projects
           li.nav-item(class=title=='Projects'?'active':undefined)
             a.nav-link(href='/projects') Projects
-        if brigade.theme.show.blog
+        if brigade.theme.page.blog
           li.nav-item(class=title=='Blog'?'active':undefined)
             a.nav-link(href='/blog') Blog
-        if brigade.theme.show.about
+        if brigade.theme.page.about
           li.nav-item(class=title=='Contact'?'active':undefined)
             a.nav-link(href='/contact') Contact

--- a/themes/atl/views/partials/header.jade
+++ b/themes/atl/views/partials/header.jade
@@ -50,6 +50,10 @@ nav.navbar.navbar-light.bg-faded.navbar-fixed-top
         if brigade.theme.page.blog
           li.nav-item(class=title=='Blog'?'active':undefined)
             a.nav-link(href='/blog') Blog
+        each external in brigade.theme.page.external
+          li.nav-item
+            a.nav-link(href=external.link, target=external.target)=external.name
         if brigade.theme.page.about
           li.nav-item(class=title=='Contact'?'active':undefined)
             a.nav-link(href='/contact') Contact
+        


### PR DESCRIPTION
### Description

Adds the ability to add custom navigation links. Also adds elevating github auths.
#### Added
- Custom external navigation links
- form in manage brigade to add new link (still not entirely functioning, will take another look tomorrow)
- middleware for authentication, checking user roles and checking github scopes available
- controller to elevate github scopes if needed
#### Changed
- Routes: now are specifying allowed roles and needed github scopes
- Header: styling and format changes to account dropdown:
  - ![](https://i.imgur.com/wllAbgf.png)
### Relevant Open Issues
- #221 
### Existing PRs with overlapping scope
- #209
### Checklist
- [x] This Pull Request template has actually been modified with relevant data ;)
- [x] This PR passes Linting tests (see below)
- [ ] This PR does not contain merge conflicts with `edge` (see below)
- [x] This PR does not contain:
  - Additional Dependencies in `package.json` that are not used
  - Frontend JS in Jade templates (unless absolutely necessary)
  - Any functionality which depends on frontend JS being enabled (unless already discussed as a team)
- [x] This PR, if overlapping with another open PR in scope, has been tested with those code changes and verified to play nice with it
