### PR TITLE
Removing require-dir duplicate from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "multiline": "^1.0.2",
     "nodemon": "^1.9.1",
     "precommit-hook": "latest",
-    "require-dir": "^0.3.0",
     "seedling": "0.0.10",
     "supertest": "^1.1.0",
     "tape": "^4.5.1",


### PR DESCRIPTION
### Description

_Removing require-dir duplication_
#### Fixed
- This should fix the warning about duplicate require-dirs on npm install #208 
### Checklist
- [x] This Pull Request template has actually been modified with relevant data ;)
- [x] This PR passes Linting tests (see below)
- [x] This PR does not contain merge conflicts with `edge` (see below)
- [x] This PR does not contain:
  - Additional Dependencies in `package.json` that are not used
  - Frontend JS in Jade templates (unless absolutely necessary)
  - Any functionality which depends on frontend JS being enabled (unless already discussed as a team)
