### PR TITLE
hide user email fields from the contact page if the user's email is u…

### DIFF
--- a/themes/codeforpoland/views/contact/index.jade
+++ b/themes/codeforpoland/views/contact/index.jade
@@ -23,7 +23,7 @@ block content
                 p #{user.profile.position}
               else
                 p position placeholder
-              if user.profile.showcontact
+              if (user.profile.showcontact && user.email)
                 p
                   a(href="mailto: #{user.email}") email
     .col-sm-3


### PR DESCRIPTION
### Description

fix contact page issue with displaying undefined emails
#### Fixed
- now hides email fields of users on the contact page if they do not have their emails defined
### Relevant Open Issues
#263
