### PR TITLE
Fix/events

### DIFF
--- a/controllers/events.js
+++ b/controllers/events.js
@@ -77,6 +77,11 @@ module.exports = {
     var endString = req.body.endday + req.body.endmonth + req.body.endyear + req.body.endhour + req.body.endminute
     newEvent.start = moment.tz(startString, 'DD-MMM-YYYY HH:mm:ss', res.locals.brigade.location.timezone).format('X')
     newEvent.end = moment.tz(endString, 'DD-MMM-YYYY HH:mm:ss', res.locals.brigade.location.timezone).format('X')
+    if (newEvent.end < newEvent.start) {
+      req.flash('errors', {msg: 'You can not create an event with an end time earlier than its start time.'})
+      res.redirect('/events/new')
+      return
+    }
     newEvent.save(function (err) {
       if (err) console.error(err)
     })

--- a/themes/codeforpoland/views/events/index.jade
+++ b/themes/codeforpoland/views/events/index.jade
@@ -35,7 +35,10 @@ block content
               td #{event.host}
               td #{event.location}
               td
-                a(href='#{event.url}', class="mu-rsvp-btn") RSVP
+                if (event.url.indexOf('meetup.com') > -1)
+                  a(href='#{event.url}', class="mu-rsvp-btn") RSVP
+                else
+                  a(href='#{event.url}', class="btn btn-primary btn-sm") Link
   script.
     ! function(d, s, id) {
       var js, fjs = d.getElementsByTagName(s)[0];

--- a/themes/codeforpoland/views/events/manage.jade
+++ b/themes/codeforpoland/views/events/manage.jade
@@ -8,11 +8,6 @@ block content
       button.btn.btn-primary(type='submit')
         i.fa.fa-refresh
         | Fetch Meetup Events
-    form.pull-right(method='POST', action='/events/delete')
-      input(type='hidden', name='_csrf', value=_csrf)
-      button.btn.btn-primary(type='submit')
-        i.fa.fa-refresh
-        | Delete All Events
   .row
     h1 All events
     table.table
@@ -39,3 +34,9 @@ block content
                 input(type='hidden', name='_csrf', value=_csrf)
                 button(type='submit')
                   | Delete
+  .row
+    form.pull-right(method='POST', action='/events/delete')
+      input(type='hidden', name='_csrf', value=_csrf)
+      button.btn.btn-primary(type='submit')
+        i.fa.fa-refresh
+        | Delete All Events

--- a/themes/codeforpoland/views/events/new.jade
+++ b/themes/codeforpoland/views/events/new.jade
@@ -8,11 +8,11 @@ block content
         .form-group
           label.col-sm-3.control-label(for='title') Event title
           .col-sm-7
-            input.form-control(type='name', name='title', id='title', value='')
+            input.form-control(type='name', name='title', id='title', required)
         .form-group
           label.col-sm-3.control-label(for='location') Location
           .col-sm-7
-            input.form-control(type='location', name='location', id='location', value='')
+            input.form-control(type='location', name='location', id='location', required)
         .form-group
           label.col-sm-3.control-label(for='host') Host
           .col-sm-7
@@ -70,7 +70,7 @@ block content
         .form-group
           label.col-sm-3.control-label(for='url') Event URL
           .col-sm-7
-            input.form-control(type='name', name='url', id='url', value='')
+            input.form-control(type='name', name='url', id='url', required)
         .form-group
           label.col-sm-3.control-label(for='description') Description
           .col-sm-7


### PR DESCRIPTION
### Description

fix some minor bugs in event pages. 
#### Added
- add button class to non-meetup event links on events/index to standardize design. 
#### Fixed
- move 'delete events' button away from 'fetch events' on events/manage.
- prevent events with end times earlier than start times from being created.
#### Changed
- require new events to have an event url, title, and location in events/new form. 
### Relevant Open Issues
- #281 
- #282 
- #277 
