### PR TITLE
feat(commit): enforcing contribution guidelines

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "babel-cli": "^6.6.5",
     "blessed": "^0.1.81",
     "blue-tape": "^0.2.0",
-    "careful": "^1.0.1",
+    "careful": "^1.0.2",
     "chai": "^3.4.1",
     "ghooks": "^1.2.1",
     "goosestrap": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,9 @@
     "babel-cli": "^6.6.5",
     "blessed": "^0.1.81",
     "blue-tape": "^0.2.0",
+    "careful": "^1.0.1",
     "chai": "^3.4.1",
+    "ghooks": "^1.2.1",
     "goosestrap": "^1.0.0",
     "mocha": "^2.3.4",
     "mongodb": "^2.1.7",
@@ -97,7 +99,8 @@
     "seedling": "0.0.10",
     "supertest": "^1.1.0",
     "tape": "^4.5.1",
-    "tape-catch": "^1.0.4"
+    "tape-catch": "^1.0.4",
+    "validate-commit-msg": "^2.6.1"
   },
   "standard": {
     "globals": [
@@ -108,9 +111,40 @@
       "after"
     ]
   },
-  "license": "ISC",
-  "pre-commit": [
-    "lint",
-    "test"
-  ]
+  "config": {
+    "validate-commit-msg": {
+      "helpMessage": "Commit message \n\n\t%s\nis not following this project's commit standards. Please refer to the contribution wiki (https://github.com/sfbrigade/brigadehub/wiki/Contributing#default-commit-message-format) for more details."
+    },
+    "careful": {
+      "prefixes": [
+        "feature",
+        "hotfix",
+        "release",
+        "bugfix",
+        "docs"
+      ],
+      "suggestions": {
+        "features": "feature",
+        "feat": "feature",
+        "fix": "bugfix",
+        "releases": "release"
+      },
+      "skip": [
+        "demo"
+      ],
+      "disallowed": [
+        "edge",
+        "master"
+      ],
+      "banned": [
+        "wip"
+      ],
+      "seperator": "/"
+    },
+    "ghooks": {
+      "pre-commit": "npm test && careful",
+      "commit-msg": "validate-commit-msg"
+    }
+  },
+  "license": "ISC"
 }


### PR DESCRIPTION
### Description

This PR will begin enforcing two things: **git branch naming**, and **commit message format**. 

Refer to the [Contributing wiki](https://github.com/sfbrigade/brigadehub/wiki/Contributing#branch-naming-format) for more details about those standards.
#### Added
- Deps:
  - `ghooks`
  - `careful`
  - `validate-commit-msg`
#### Removed
- `pre-commit` dep (`ghooks` supercedes it)
### Relevant Open Issues
- #241 
### Checklist
- [x] This Pull Request template has actually been modified with relevant data ;)
- [x] This PR passes Linting tests (see below)
- [x] This PR does not contain merge conflicts with `edge` (see below)
- [x] This PR does not contain:
  - Additional Dependencies in `package.json` that are not used
  - Frontend JS in Jade templates (unless absolutely necessary)
  - Any functionality which depends on frontend JS being enabled (unless already discussed as a team)
- [x] This PR, if overlapping with another open PR in scope, has been tested with those code changes and verified to play nice with it
