### PR TITLE
fix(project): admin can delete and unpublish from manage page

### DIFF
--- a/app.js
+++ b/app.js
@@ -264,6 +264,11 @@ app.post('/projects/:projectId/sync',
   passportConf.checkRoles(['lead', 'core', 'superAdmin']),
   passportConf.checkScopes(['user', 'repo']),
   projectsCtrl.postProjectsIDSync)
+app.post('/projects/:projectId/delete',
+  passportConf.isAuthenticated,
+  passportConf.checkRoles(['lead', 'core', 'superAdmin']),
+  passportConf.checkScopes(['user', 'repo']),
+  projectsCtrl.postDeleteProject)
 
 /**
  * Events routes.

--- a/controllers/projects.js
+++ b/controllers/projects.js
@@ -80,7 +80,28 @@ module.exports = {
    * Update all Projects.
    */
   postProjectsManage: function (req, res) {
-    res.redirect('projects/manage')
+    req.flash('success', { msg: 'Success! Projects edited' })
+    var mongooseQuery = {}
+    //  if (!res.locals.user.isAdmin()) {
+    //   //  mongooseQuery.author = res.locals.user.username
+    //  }
+    Projects.find(mongooseQuery, function (err, projects) {
+      if (err) console.error(err)
+      projects.reverse() // so that most recent are first
+      projects.forEach(function (project) {
+        var projectInfo = req.body[project.id]
+        if (projectInfo.delete) {
+          project.remove()
+          return
+        }
+        project.name = projectInfo.name
+        project.published = !!projectInfo.published
+        project.save(function (err) {
+          if (err) throw err
+        })
+      })
+    })
+    return res.redirect('/projects/manage/')
   },
   /**
    * GET /projects/new
@@ -241,6 +262,21 @@ module.exports = {
     Projects.fetchGithubRepos(res.locals.brigade, req.user, function (results) {
       req.flash('success', { msg: 'Success! You have successfully synced projects from Github.' })
       res.redirect('/projects/manage')
+    })
+  },
+  /**
+   * POST /projects/delete
+   * Delete a project
+   */
+  postDeleteProject: function (req, res) {
+    Projects.remove({id: req.params.projectId}, function (err) {
+      if (err) {
+        console.log(err)
+        return res.redirect('/projects/' + req.params.projectId)
+      } else {
+        req.flash('success', {msg: 'Your project was deleted.'})
+        return res.redirect('/projects/')
+      }
     })
   },
   /**

--- a/models/Posts.js
+++ b/models/Posts.js
@@ -15,7 +15,7 @@ var postsSchema = new mongoose.Schema({
   description: {type: String, default: ''},
   content: {type: String, default: ''},
   date: {type: String, default: ''},
-  published: {type: Boolean, default: ''},
+  published: {type: Boolean, default: false},
   unix: {type: Number, default: 0},
   sync: {
     jekyll: {type: String, default: ''},

--- a/models/Projects.js
+++ b/models/Projects.js
@@ -39,7 +39,8 @@ var projectsSchema = new mongoose.Schema({
   data: {type: Array, default: []},
   keywords: {type: Array, default: []}, // simple strings
   links: {type: Array, default: []}, // simple strings
-  videos: {type: Array, default: []}
+  videos: {type: Array, default: []},
+  published: {type: Boolean, default: true}
 })
 
 projectsSchema.statics.fetchGithubRepos = function (brigade, user, cb) {

--- a/themes/codeforpoland/views/blog/index.jade
+++ b/themes/codeforpoland/views/blog/index.jade
@@ -13,25 +13,25 @@ mixin sidebarItem(name,subItems,selectedItem)
           a(href="?#{name}=#{item}")= item
 
 block content
-  .row.breadcrumbs
+  .breadcrumbs
     .col-sm-12
       a(href='/')= brigade.name
       | &nbsp;&nbsp;/&nbsp; 
       a(href='/blog') Blog
-  .row.page-header
+  .page-header
     .col-sm-12
       h1.page-title Blog
   if user && user.isBlogger()
     a.btn.btn-secondary(href='/blog/new') New Post
-  .row
+  .la
     hr
   .container
-    .row
+    .la
       .col-sm-3.sidebar
         ul
           mixin sidebarItem('tag',tags,selectedTag)
       .col-sm-9
-        .row
+        .la
           each post in posts
             if post.published
               .col-sm-6
@@ -54,7 +54,7 @@ block content
                       each tag in post.tags
                         a.badge(href="?tag=#{tag}")= tag
         if totalPages > 1
-          .row.col-md-12
+          .col-md-12
             if page > 1 
               a(href=currentUrl+(+page-1)) 
                 i(class="fa fa-arrow-left" aria-hidden="true")

--- a/themes/codeforpoland/views/projects/index.jade
+++ b/themes/codeforpoland/views/projects/index.jade
@@ -34,20 +34,21 @@ block content
       .col-sm-9
         .row
         each project in projects
-          .col-sm-6
-            .card.project-list-card
-                a(href='/projects/#{project.id}')
-                  span.thumbnail(style='background-image:url(#{project.thumbnailUrl});').img-fluid.card-img-top
-                .card-block
-                  h3.card-title
-                    a(href='/projects/#{project.id}')
-                      =project.name
-                  p.card-text= project.description
-                  p.card-keywords
-                    span Keywords
-                    each keyword in project.keywords
-                      a.badge(href="?keyword=#{keyword}")= keyword
-                  p.card-needs
-                    span Needs
-                    each need in project.needs
-                      a.badge(href="?need=#{need}")= need
+          if project.published
+            .col-sm-6
+              .card.project-list-card
+                  a(href='/projects/#{project.id}')
+                    span.thumbnail(style='background-image:url(#{project.thumbnailUrl});').img-fluid.card-img-top
+                  .card-block
+                    h3.card-title
+                      a(href='/projects/#{project.id}')
+                        =project.name
+                    p.card-text= project.description
+                    p.card-keywords
+                      span Keywords
+                      each keyword in project.keywords
+                        a.badge(href="?keyword=#{keyword}")= keyword
+                    p.card-needs
+                      span Needs
+                      each need in project.needs
+                        a.badge(href="?need=#{need}")= need

--- a/themes/codeforpoland/views/projects/manage.jade
+++ b/themes/codeforpoland/views/projects/manage.jade
@@ -9,33 +9,46 @@ block content
       | &nbsp;&nbsp;/&nbsp;
       a(href='/projects/manage') Manage
 
-  .row.page-header
-    h3.pull-left Manage Projects
-  .row
-    .col-sm-12
+  .page-header
+    h3 Manage Projects
+    if user && user.isAdmin()
+      a(href='/projects/new') New Project
+    |&nbsp;&nbsp;&nbsp;
+    form.row.form-horizontal(action='/projects/manage', method='POST', id='projectsform')
+      input(type='hidden', name='_csrf', value=_csrf)
       table.table
-        thead
+        thread
           tr
-            th
-              input.select-all(type="checkbox")
+            th Published?
             th Project Name
             th Project Repo
             th Project Description
             th Project Homepage
             th Edit project
-            th
-              a(href='/projects/new') New Project
+            th Delete?
         tbody
           each project in projects
             tr
               td
-                input.select-project(type="checkbox", value=project.slug)
-              td.name
-               a(href='/projects/#{project.id}') #{project.name}
-              td.id
-                a(href=project.repository, target="_blank") Link
-              td.description= project.description
-              td.homepage
-                a(href=project.homepage, target="_blank")= project.homepage
-              td.edit
-                a(href='/projects/#{project.id}/settings') Edit
+                if project.published
+                  input(type='checkbox', checked, name='#{project.id}[published]', id='published')
+                else
+                  input(type='checkbox', name='#{project.id}[published]', id='published')
+              td
+                input(type='text', name='#{project.id}[name]', value='#{project.name}')
+                td.id
+                  a(href=project.repository, target="_blank") Link
+                td.description= project.description
+                td.homepage
+                  a(href=project.homepage, target="_blank")= project.homepage
+                td.edit
+                  a(href='/projects/#{project.id}/settings') Edit
+              td
+                input(type='checkbox', name='#{project.id}[delete]' id="delete")
+                i(class="fa fa-trash-o" aria-hidden="true")
+
+      .form-group.row
+        .col-sm-4
+          button.btn.btn.btn-primary(type='submit')
+            i.fa.fa-pencilr
+            | Save Changes

--- a/themes/codeforpoland/views/projects/project.jade
+++ b/themes/codeforpoland/views/projects/project.jade
@@ -15,6 +15,13 @@ block content
         img(src='#{project.thumbnailUrl}', height='50')
         | &nbsp;
         =project.name
+      if (user && (user.isAdmin() || user.isProjectLead()))
+        span  
+          form(method='POST', action='/projects/#{project.id}/delete')
+            input(type='hidden', name='_csrf', value=_csrf)
+            button.float.right.btn.btn-primary(type='submit')
+              i(class="fa fa-trash-o" aria-hidden="true")
+              | Delete
   .row
     .col-sm-12
       .banner(style="margin-bottom: 50px;")
@@ -60,7 +67,7 @@ block content
                 span.info.infobox
                   for keyword in project.keywords
                     span(class="label label-warning")= keyword
-
+                    
     //- .col-sm-3
     //-     .see-also
     //-       .links


### PR DESCRIPTION
### Description

Admin can delete and publish / unpublish projects. 
#### Added

-Delete project from project page
-Can mass edit from manage page, delete, unpublish, or edit title
#### Removed
#### Fixed
#### Changed
#### Deprecated
### Relevant Open Issues
- #1 - Need too add confirmation on delete
- #2 - Server crashes if you accidentally go to a project page that has been deleted
### Existing PRs with overlapping scope
### Screenshots of changes

MANAGE PAGE
before
![screen shot 2016-06-15 at 1 33 43 pm](https://cloud.githubusercontent.com/assets/2788860/16097636/a0ee804a-3303-11e6-8385-661295beadfd.png)

after
![image](https://cloud.githubusercontent.com/assets/2788860/16097538/1da7c17e-3303-11e6-9ff8-d6b508cc9ad1.png)

PROJECT PAGE
![image](https://cloud.githubusercontent.com/assets/2788860/16097610/85c8e652-3303-11e6-892b-202bd5840c6f.png)
### Checklist
- [x] This PR passes Linting tests (see below)
- [x] This PR does not contain merge conflicts with `develop` (see below)
- [x] This PR does not contain:
  - Additional Dependencies in `package.json` that are not used
  - Frontend JS in Jade templates (unless absolutely necessary)
