### PR TITLE
fix(footer): fit sponsor footer placement

### DIFF
--- a/themes/codeforpoland/views/partials/footer.jade
+++ b/themes/codeforpoland/views/partials/footer.jade
@@ -5,10 +5,10 @@ footer
         h3 Partners
     .row.partners-logos
       each sponsor in brigade.sponsors
-        .col-md-4
           if (!(sponsor.main))
-            a(href=sponsor.link)
-              img(src=sponsor.image, alt=sponsor.name)
+            .col-md-4
+              a(href=sponsor.link)
+                img(src=sponsor.image, alt=sponsor.name)
     //- .row.show-partners
     //-   .col-sm-12
     //-     a.btn.btn-danger(href='http://codeforpoland.org/partnerzy/') Show all partners


### PR DESCRIPTION
### Description

fix issue with footer placement of sponsors.
#### Fixed
- would insert a blank placeholder space in the footer view if a sponsor was hidden (aka designated as main in brigade/manage). changed to remove the blank placeholder space. 

![screen shot 2016-06-15 at 7 07 25 pm](https://cloud.githubusercontent.com/assets/12902506/16103373/c826c680-332c-11e6-9274-171294eb9535.png)

![screen shot 2016-06-15 at 7 07 11 pm](https://cloud.githubusercontent.com/assets/12902506/16103375/d2fed9f8-332c-11e6-843c-6dda3d885707.png)

fix footer placement of sponsors if one of the sponsors is designated as main and hidden. would put
a blank space placeholder in its stead.

no
