### PR TITLE
fix(metrics): remove vendor assets from code climate coverage

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -25,5 +25,6 @@ exclude_paths:
 - config/
 - node_modules
 - test/
-- themes/codeforpoland/public/css/vendors
-- themes/codeforpoland/public/js/lib
+- "themes/**/public/css/vendors"
+- "themes/**/public/js/lib"
+- "**.min.js"


### PR DESCRIPTION
### Description

Modifies exclude path to get rid of min.js and vendor assets
#### Added
- *N/A
#### Removed
- *N/A
#### Fixed
#362
#### Changed
- *N/A
#### Deprecated
- *N/A
### Relevant Open Issues
- *N/A
### Existing PRs with overlapping scope
- *N/A
### Screenshots of changes
- *N/A
### Checklist
- [x] This PR passes Linting tests (see below)
- [x] This PR does not contain merge conflicts with `develop` (see below)
- [x] This PR does not contain:
  - Additional Dependencies in `package.json` that are not used
  - Frontend JS in Jade templates (unless absolutely necessary)

modify exclude paths
#362
