### PR TITLE
fix(events): Change event date formatting

### DIFF
--- a/controllers/home.js
+++ b/controllers/home.js
@@ -18,7 +18,7 @@ exports.index = function (req, res) {
     foundEvents = foundEvents.filter(function (event) {
       return event.start >= moment().unix()
     }).map(function (event) {
-      event.startDate = moment.unix(event.start).format('MMM DD')
+      event.startDate = moment.unix(event.start).tz(res.locals.brigade.location.timezone).format('MMM DD')
       return event
     })
     Projects.find({brigade: res.locals.brigade.slug}, function (err, foundProjects) {


### PR DESCRIPTION
### Description

Corrected the formatting of the upcoming events date displayed on the landing page to display based on the brigade's local time not the server's local time.
#### Fixed
- Fixed the formatting of event.startDate in home.js controller.
### Checklist
- [ x ] This PR passes Linting tests (see below)
- [ x ] This PR does not contain merge conflicts with `develop` (see below)
- [ x ] This PR does not contain:
  - Additional Dependencies in `package.json` that are not used
  - Frontend JS in Jade templates (unless absolutely necessary)

Corrected the formatting of the upcoming events date displayed on the
landing page to display based on the brigade's local time not the
server's time.
