### PR TITLE
feat(events): Update layout to include sidebar

### DIFF
--- a/controllers/events.js
+++ b/controllers/events.js
@@ -14,7 +14,7 @@ module.exports = {
       var mappedEvents = foundEvents.filter(function (event) {
         return event.start > moment().unix()
       }).map(function (event) {
-        event.convertedstart = moment.unix(event.start).tz(res.locals.brigade.location.timezone).format('ha z MMMM DD, YYYY')
+        event.convertedstart = moment.unix(event.start).tz(res.locals.brigade.location.timezone).format('MMMM DD, YYYY ha z')
         return event
       })
       res.render(res.locals.brigade.theme.slug + '/views/events/index', {

--- a/themes/codeforpoland/public/css/views/event-list.scss
+++ b/themes/codeforpoland/public/css/views/event-list.scss
@@ -1,3 +1,44 @@
 [data-view='event-list'] {
+  .upcoming-title {
+    margin-top: 1rem;
+  }
+  .upcoming {
+    overflow: auto;
 
+    height: 640px;
+    @media (max-width: 61.9em) {
+      overflow: none;
+
+      height: auto;
+    }
+  }
+  .event-card {
+    position: relative;
+
+    display: block;
+
+    margin-bottom: 0.75rem;
+    padding: 0.75rem 0.75rem;
+
+    border-bottom: 1px solid  #e5e5e5;
+    &:last-child {
+      border: none;
+    }
+    .event-title {
+      margin-bottom: 0.75rem;
+    }
+    .event-date {
+      font-weight: bold;
+
+      margin-bottom: 0.75rem;
+
+      color: $brand-red;
+    }
+    .event-text {
+      line-height: 1.2;
+
+      margin-top: 0;
+      margin-bottom: 0.75rem;
+    }
+  }
 }

--- a/themes/codeforpoland/views/events/index.jade
+++ b/themes/codeforpoland/views/events/index.jade
@@ -14,46 +14,36 @@ block content
   if user && user.isAdmin()
     a.btn.btn-secondary(href='/events/new') New Event
   .row
-    .col-sm-12
+    .col-xl-9.col-lg-8
       p
         #events-calendar
-  script.
-    // make this object available to frontend js for rendering in calendar
-    window._events = !{JSON.stringify(events).replace(/<\//g, "<\\/")}
-  .row
-    .col-sm-12
-      h1 Upcoming events list
-      table.table
-        thead
-          tr
-            th Event name
-            th Date & time
-            th Host
-            th Address
-            th
-        tbody
-          each event, i in upcomingevents
-            tr
-              td #{event.title}
-              td
-                |User converted time: <span class = event#{i}></span>
-                br
-                |Local event time: #{event.convertedstart}
-              td #{event.host}
-              td #{event.location}
-              td
-                if (event.url.indexOf('meetup.com') > -1)
-                  a(href='#{event.url}', class="mu-rsvp-btn") RSVP
-                else
-                  a(href='#{event.url}', class="btn btn-danger btn-sm") Link
-  script.
-    ! function(d, s, id) {
-      var js, fjs = d.getElementsByTagName(s)[0];
-      if (!d.getElementById(id)) {
-          js = d.createElement(s);
-          js.id = id;
-          js.async = true;
-          js.src = "https://a248.e.akamai.net/secure.meetupstatic.com/s/script/2012676015776998360572/api/mu.btns.js?id=#{brigade.auth.meetup.consumerKey}";
-          fjs.parentNode.insertBefore(js, fjs);
-      }
-    }(document, "script", "mu-bootjs");
+    script.
+      // make this object available to frontend js for rendering in calendar
+      window._events = !{JSON.stringify(events).replace(/<\//g, "<\\/")}
+    .col-xl-3.col-lg-4
+      h2.upcoming-title Upcoming Events
+      .upcoming
+        each event, i in upcomingevents
+          .event-card
+            h5.event-title #{event.title}
+            p.event-date #{event.convertedstart}
+            p.event-text
+              |#{event.host}
+              br
+              |#{event.location}
+            p.event-text
+              if (event.url.indexOf('meetup.com') > -1)
+                a(href='#{event.url}', class="mu-rsvp-btn") RSVP
+              else
+                a(href='#{event.url}', class="btn btn-red btn-sm") Link
+    script.
+      ! function(d, s, id) {
+        var js, fjs = d.getElementsByTagName(s)[0];
+        if (!d.getElementById(id)) {
+            js = d.createElement(s);
+            js.id = id;
+            js.async = true;
+            js.src = "https://a248.e.akamai.net/secure.meetupstatic.com/s/script/2012676015776998360572/api/mu.btns.js?id=#{brigade.auth.meetup.consumerKey}";
+            fjs.parentNode.insertBefore(js, fjs);
+        }
+      }(document, "script", "mu-bootjs");

--- a/themes/codeforpoland/views/partials/footer.jade
+++ b/themes/codeforpoland/views/partials/footer.jade
@@ -5,13 +5,13 @@ footer
         h3 Partners
     .row.partners-logos
       each sponsor in brigade.sponsors
-          if (!(sponsor.main))
-            .col-md-4
-              a(href=sponsor.link)
-                img(src=sponsor.image, alt=sponsor.name)
-    //- .row.show-partners
-    //-   .col-sm-12
-    //-     a.btn.btn-danger(href='http://codeforpoland.org/partnerzy/') Show all partners
+        if (!(sponsor.main))
+          .col-md-4
+            a(href=sponsor.link)
+              img(src=sponsor.image, alt=sponsor.name)
+  //- .row.show-partners
+  //-   .col-sm-12
+  //-     a.btn.btn-danger(href='http://codeforpoland.org/partnerzy/') Show all partners
   .row.footer-nav
     .col-sm-12
       ul


### PR DESCRIPTION
### Description

Updated the events index page to display upcoming events in a sidebar on desktop and tablet landscape views. Otherwise the upcoming events display in a single column under the events calendar.
#### Changed
- Upcoming Events layout in desktop and mobile views.
### Relevant Open Issues
- #381
### Screenshots of changes

![Events Page - Desktop View](https://i.imgur.com/sg3D3iD.png)
![Events Page - Mobile View](https://i.imgur.com/v9C140u.png)
### Checklist
- [ x ] This PR passes Linting tests (see below)
- [ x ] This PR does not contain merge conflicts with `develop` (see below)
- [ x ] This PR does not contain:
  - Additional Dependencies in `package.json` that are not used
  - Frontend JS in Jade templates (unless absolutely necessary)

Updated the events index page to display upcoming events in a sidebar
on desktop and tablet landscape views. Otherwise the upcoming events
display in a single column under the events calendar.
