### PR TITLE
fix(landing): fix display of blog posts' publish time on landing

### DIFF
--- a/controllers/home.js
+++ b/controllers/home.js
@@ -33,10 +33,7 @@ exports.index = function (req, res) {
       })
       Posts.find({}, function (err, foundPosts) {
         if (err) console.error(err)
-        foundPosts = foundPosts.slice(0, 3).map(function (post) {
-          post.date = moment.unix(post.unix).format('MMMM DD, YYYY')
-          return post
-        })
+        foundPosts = foundPosts.slice(0, 3)
         res.render(res.locals.brigade.theme.slug + '/views/home', {
           view: 'home',
           title: 'Home',


### PR DESCRIPTION
### Description

fix display of blog posts' publish time on landing
#### Fixed
- fix display of blog posts' publish time on landing by no longer invoking moment on time string
### Relevant Open Issues
- #368 

fix display of blog posts' publish time on landing

closes #368
