### PR TITLE
Feature/stats

### DIFF
--- a/themes/codeforpoland/public/css/themes/default/_default.scss
+++ b/themes/codeforpoland/public/css/themes/default/_default.scss
@@ -18,7 +18,7 @@
 }
 
 .btn-red {
-  transition: background-color 0.3s;
+  transition: background-color 0.5s;
 
   color: #ffffff;
   border-color: $brand-red;

--- a/themes/codeforpoland/public/css/views/landing.scss
+++ b/themes/codeforpoland/public/css/views/landing.scss
@@ -247,14 +247,31 @@
       }
     }
   }
+  .centered {
+    margin: 0 auto;
+    padding: 0 1em;
+  }
   #landing-stats {
+    display: flex;
+    justify-content: space-around;
+    height: 108px;
+
+    .landing-stat {
+      display: flex;
+      flex: 0 0 28%;
+    }
+    .landing-stat:first-child:nth-last-child(4),
+    .landing-stat:first-child:nth-last-child(4) ~ .landing-stat {
+      flex: 0 0 25%;
+    }
     .col-sm-5 {
       position: relative;
 
       height: 108px;
     }
     img {
-      position: absolute;
+      display: block;
+      position: relative;
       top: 50%;
       left: 50%;
 

--- a/themes/codeforpoland/public/css/views/landing.scss
+++ b/themes/codeforpoland/public/css/views/landing.scss
@@ -253,15 +253,16 @@
   }
   #landing-stats {
     display: flex;
-    justify-content: space-around;
+
     height: 108px;
 
+    justify-content: space-around;
     .landing-stat {
       display: flex;
+
       flex: 0 0 28%;
     }
-    .landing-stat:first-child:nth-last-child(4),
-    .landing-stat:first-child:nth-last-child(4) ~ .landing-stat {
+    .landing-stat:first-child:nth-last-child(4), .landing-stat:first-child:nth-last-child(4) ~ .landing-stat {
       flex: 0 0 25%;
     }
     .col-sm-5 {
@@ -270,10 +271,11 @@
       height: 108px;
     }
     img {
-      display: block;
       position: relative;
       top: 50%;
       left: 50%;
+
+      display: block;
 
       transform: translateY(-50%) translateX(-50%);
     }

--- a/themes/codeforpoland/views/home.jade
+++ b/themes/codeforpoland/views/home.jade
@@ -48,42 +48,39 @@ block content
                     span.event-date  #{event.startDate}
                     span.event-title #{event.title}
   hr
-  #landing-stats.center-block.row.hidden-md-down
-    .col-sm-3
-      #landing-stat-1.landing-stat
-        .row.text-xs-center.center-block
+  .centered
+    #landing-stats.hidden-md-down
+      .landing-stat
+        .row.text-xs-center
           .col-sm-5
-            img.img-fluid(src="http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-forum.png")
+            img(src="http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-forum.png")
           .col-sm-7
             p
               strong #{brigade.slackcount}
             p.txt
               | Slackers registered
-    .col-sm-3
-      #landing-stat-2.landing-stat
-        .row.text-xs-center.center-block
+      .landing-stat
+        .row.text-xs-center
           .col-sm-5
-            img.img-fluid(src="http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-ideas.png")
+            img(src="http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-ideas.png")
           .col-sm-7
             p
               strong #{postcount}
             p.txt
               | Ideas being discussed
-    .col-sm-3
-      #landing-stat-3.landing-stat
-        .row.text-xs-center.center-block
+      .landing-stat
+        .row.text-xs-center
           .col-sm-5
-            img.img-fluid(src="http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-citylab.png")
+            img(src="http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-citylab.png")
           .col-sm-7
             p
               strong #{brigade.brigadecount}
             p.txt
               | Bay Area Brigades
-    .col-sm-3
-      #landing-stat-4.landing-stat
-        .row.text-xs-center.center-block
+      .landing-stat
+        .row.text-xs-center
           .col-sm-5
-            img.img-fluid(src="http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-projects.png")
+            img(src="http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-projects.png")
           .col-sm-7
             p
               strong #{projectcount}


### PR DESCRIPTION
### Description

Changed landing stats layout from using Bootstrap columns to using flexbox. This will keep a consistent styling even if less than 4 stats are displayed.
### Checklist
- [ X ] This PR passes Linting tests (see below)
- [ X ] This PR does not contain merge conflicts with `develop` (see below)
- [ X ] This PR does not contain:
  - Additional Dependencies in `package.json` that are not used
  - Frontend JS in Jade templates (unless absolutely necessary)

Switched the layout formatting to take advantage of flexboxes in
preparation for user added stats.
