### PR TITLE
pin phantomjs to 2.1.11 exactly

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "mongodb": "^2.1.7",
     "nightwatch": "latest",
     "nodemon": "^1.9.1",
-    "phantomjs-prebuilt": "^2.1.11",
+    "phantomjs-prebuilt": "2.1.11",
     "seedling": "0.0.10",
     "selenium-standalone": "latest",
     "validate-commit-msg": "^2.6.1"


### PR DESCRIPTION
We are seeing build errors on travis that seem to indicate an issue with
2.11.12.
