### PR TITLE
Feature/viewable stats

### DIFF
--- a/controllers/brigade.js
+++ b/controllers/brigade.js
@@ -100,6 +100,10 @@ exports.postBrigade = function (req, res, next) {
           thisBrigade.landingstats.push(req.body['new-landingstat'])
         }
       }
+      var displayedstats = thisBrigade.landingstats.filter(function (landingstat) {
+        return landingstat.display === '1'
+      })
+      thisBrigade.displayedstats = displayedstats
       req.body['externals'] = req.body['externals'] || []
       var links = req.body['externals'].filter(function (link) {
         if (!link.delete) {

--- a/models/Brigade.js
+++ b/models/Brigade.js
@@ -46,6 +46,7 @@ var brigadeSchema = new mongoose.Schema({
   },
   sponsors: {type: Array, default: []},
   landingstats: {type: Array, default: []},
+  displayedstats: {type: Array, default: []},
   auth: {
     github: {
       clientId: {type: String, default: ''},

--- a/seeds/development/Brigade.js
+++ b/seeds/development/Brigade.js
@@ -75,6 +75,66 @@ module.exports = function () {
         image: 'https://i.imgur.com/jdbLl87.png'
       }
     ],
+    landingstats: [
+      {
+        imglink: 'http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-forum.png',
+        link: 'undefined',
+        stat: '554',
+        caption: 'Slackers Registered',
+        display: '1'
+      },
+      {
+        imglink: 'http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-ideas.png',
+        link: '/blog',
+        stat: '31',
+        caption: 'Ideas Being Discussed',
+        display: '1'
+      },
+      {
+        imglink: 'http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-citylab.png',
+        link: 'undefined',
+        stat: '4',
+        caption: 'Bay Area Brigades',
+        display: '1'
+      },
+      {
+        imglink: 'http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-projects.png',
+        link: '/projects',
+        stat: '8',
+        caption: 'Active Projects',
+        display: '1'
+      }
+    ],
+    displayedstats: [
+      {
+        imglink: 'http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-forum.png',
+        link: 'undefined',
+        stat: '554',
+        caption: 'Slackers Registered',
+        display: '1'
+      },
+      {
+        imglink: 'http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-ideas.png',
+        link: '/blog',
+        stat: '31',
+        caption: 'Ideas Being Discussed',
+        display: '1'
+      },
+      {
+        imglink: 'http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-citylab.png',
+        link: 'undefined',
+        stat: '4',
+        caption: 'Bay Area Brigades',
+        display: '1'
+      },
+      {
+        imglink: 'http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-projects.png',
+        link: '/projects',
+        stat: '8',
+        caption: 'Active Projects',
+        display: '1'
+      }
+    ],
     auth: {
       github: {
         clientId: process.env.GITHUB_ID,

--- a/themes/codeforpoland/public/css/views/landing.scss
+++ b/themes/codeforpoland/public/css/views/landing.scss
@@ -257,10 +257,22 @@
     height: 108px;
 
     justify-content: space-around;
+    a {
+      color: #373a3c;
+
+      transition: box-shadow 0.4s;
+
+      &:hover {
+        box-shadow: 0 0 5px #e4e4e4;
+
+        transition: box-shadow 0.4s;
+      }
+    }
     .landing-stat {
       display: flex;
 
-      flex: 0 0 28%;
+      flex: 0 0 33%;
+
     }
     .landing-stat:first-child:nth-last-child(4), .landing-stat:first-child:nth-last-child(4) ~ .landing-stat {
       flex: 0 0 25%;
@@ -279,13 +291,10 @@
 
       transform: translateY(-50%) translateX(-50%);
     }
-    strong {
+    .stat {
       font-size: 72px;
       font-weight: 700;
       line-height: 80%;
-
-      margin-top: -5px;
-      margin-bottom: 5px;
 
       color: #d20a11;
     }

--- a/themes/codeforpoland/views/brigade.jade
+++ b/themes/codeforpoland/views/brigade.jade
@@ -131,28 +131,28 @@ block content
           .col-sm-4.checkbox
             label
               input.title(id="show-title", name="show-title", type="checkbox", checked=(brigade.theme.page.title ? "checked" : undefined))
-              | Show Brigade Name
+              | &nbsp;&nbsp;Show Brigade Name
           .col-sm-4.checkbox
             label
               input.events(id="show-events", name="show-events", type="checkbox", checked=(brigade.theme.page.events ? "checked" : undefined))
-              | Show Events Pages
+              | &nbsp;&nbsp;Show Events Pages
           .col-sm-4.checkbox
             label
               input.projects(id="show-projects", name="show-projects", type="checkbox", checked=(brigade.theme.page.projects ? "checked" : undefined))
-              | Show Projects Pages
+              | &nbsp;&nbsp;Show Projects Pages
         .row
           .col-sm-4.checkbox
             label
               input.blog(id="show-blog", name="show-blog", type="checkbox", checked=(brigade.theme.page.blog ? "checked" : undefined))
-              | Show Blog Pages
+              | &nbsp;&nbsp;Show Blog Pages
           .col-sm-4.checkbox
             label
               input.about(id="show-about", name="show-about", type="checkbox", checked=(brigade.theme.page.about ? "checked" : undefined))
-              | Show About Page
+              | &nbsp;&nbsp;Show About Page
           .col-sm-4.checkbox
             label
               input.login(id="show-login", name="show-login", type="checkbox", checked=(brigade.theme.page.login ? "checked" : undefined))
-              | Show Login Page
+              | &nbsp;&nbsp;Show Login Page
       .form-group
         .col-sm-offset-3.col-sm-4
           button.btn.btn.btn-primary(type='submit')
@@ -228,7 +228,7 @@ block content
                     i.static.fa.fa-pencil
                     i.update.hidden.fa.fa-close
                   label.delete-checkbox(for='sponsors-#{index}-delete')
-                    input.hidden(type='checkbox', name='sponsors[#{index}][delete]', id='sponsors-#{index}-delete')
+                    input.hidden(type='submit', name='sponsors[#{index}][delete]', id='sponsors-#{index}-delete')
                     span.btn.btn-danger(type='button')
                       i.fa.fa-trash
                 td
@@ -242,15 +242,18 @@ block content
                 input.form-control(name='new-sponsor[image]', id='new-sponsor-image', value='', placeholder='Sponsor image')
               td
                 button.btn.btn-primary(type='submit') Save Changes
-      h3 Brigade Landing-Stats
+      h3 Brigade Landing Statistics
+        small  (Max 4 Stats Displayed)
       .row.row-body
         table.table
           thead
             tr
               th Image Link
               th Link To
-              th Caption
               th Stat
+              th Caption
+              th Actions
+              th Display
           tbody
             each landingstat, index in brigade.landingstats
               tr
@@ -261,11 +264,11 @@ block content
                   span.static=landingstat.link
                   input.update.hidden.form-control(type='text', name='landingstats[#{index}][link]', id='landingstat-link-link', value='#{landingstat.link}')
                 td
+                  span.static=landingstat.stat
+                  input.update.hidden.form-control(type='text', name='landingstats[#{index}][stat]', id='landingstat-link-stat', value='#{landingstat.stat}')
+                td
                   span.static=landingstat.caption
                   input.update.hidden.form-control(type='text', name='landingstats[#{index}][caption]', id='landingstat-link-caption', value='#{landingstat.caption}')
-                td
-                  span.static=landingstat.stat
-                  input.update.hidden.form-control(type='text', name='landingstats[#{index}][stat]', id='landingstat-link-stat', value='#{landingstat.stat}')    
                 td
                   button.edit-settings-row.btn.btn-primary(type='button')
                     i.static.fa.fa-pencil
@@ -274,15 +277,21 @@ block content
                     input.hidden(type='submit', name='landingstats[#{index}][delete]', id='landingstats-#{index}-delete')
                     span.btn.btn-danger(type='button')
                       i.fa.fa-trash
+                td
+                  label(for='landingstats-#{index}-display') Yes&nbsp;&nbsp;
+                    input(type='radio', name='landingstats[#{index}][display]', id='landingstats-#{index}-display', value='1', checked=landingstat.display==='1')
+                  label(for='landingstats-#{index}-not_displayed') No&nbsp;&thinsp;&thinsp;
+                    input(type='radio', name='landingstats[#{index}][display]', id='landingstats-#{index}-not_displayed', value='0', checked=landingstat.display==='0')
            tr
               td
                 input.form-control(name='new-landingstat[imglink]', id='new-landingstat-imglink', value='', placeholder='Image Link')
               td
                 input.form-control(name='new-landingstat[link]', id='new-landingstat-link', value='', placeholder='Destination Link')
               td
-                input.form-control(name='new-landingstat[caption]', id='new-landingstat-caption', value='', placeholder='Caption')
+                input.form-control(name='new-landingstat[stat]', id='new-landingstat-stat', value='', placeholder='Stat')
               td
-                input.form-control(name='new-landingstat[stat]', id='new-landingstat-stat', value='', placeholder='Stat')    
+                input.form-control(name='new-landingstat[caption]', id='new-landingstat-caption', value='', placeholder='Caption')
+                input.hidden(type='radio', name='new-landingstat[display]', value='0', checked)
               td
                 button.btn.btn-primary(type='submit') Save Changes
     .row.row-title

--- a/themes/codeforpoland/views/home.jade
+++ b/themes/codeforpoland/views/home.jade
@@ -50,42 +50,23 @@ block content
   hr
   .centered
     #landing-stats.hidden-md-down
-      .landing-stat
-        .row.text-xs-center
-          .col-sm-5
-            img(src="http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-forum.png")
-          .col-sm-7
-            p
-              strong #{brigade.slackcount}
-            p.txt
-              | Slackers registered
-      .landing-stat
-        .row.text-xs-center
-          .col-sm-5
-            img(src="http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-ideas.png")
-          .col-sm-7
-            p
-              strong #{postcount}
-            p.txt
-              | Ideas being discussed
-      .landing-stat
-        .row.text-xs-center
-          .col-sm-5
-            img(src="http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-citylab.png")
-          .col-sm-7
-            p
-              strong #{brigade.brigadecount}
-            p.txt
-              | Bay Area Brigades
-      .landing-stat
-        .row.text-xs-center
-          .col-sm-5
-            img(src="http://kodujdlapolski.pl/wp-content/themes/kdp/images/stats-projects.png")
-          .col-sm-7
-            p
-              strong #{projectcount}
-            p.txt
-              | Active Projects
+      each displayedstat in brigade.displayedstats.slice(0, 4)
+        if (displayedstat.link !== "undefined")
+          a.landing-stat(href=displayedstat.link)
+            .row.text-xs-center
+              .col-sm-5
+                img(src=displayedstat.imglink)
+              .col-sm-7
+                p.stat #{displayedstat.stat}
+                p.txt #{displayedstat.caption}
+        else
+          .landing-stat
+            .row.text-xs-center
+              .col-sm-5
+                img(src=displayedstat.imglink)
+              .col-sm-7
+                p.stat #{displayedstat.stat}
+                p.txt #{displayedstat.caption}
   hr.hidden-md-down
   #landing-ctas.row.center-block
     .col-md-4


### PR DESCRIPTION
### Description

Builds on the ability for a Brigade manager to add stats to be displayed on the landing page.
#### Added
- Displaystats to the Brigade model.
- Ability to select to display or not display a stat on the landing page
- Adds landingstats and displaystats to the Brigade development seed file
#### Changed
- Home page to display the newly created displaystats
#### Fixed
- Issue with Travis-CI where build would fail because phantom.js was updating to a new version not yet supported by Travis-CI
### Screenshots of changes

![Brigade Management Landing Stats](https://i.imgur.com/Ool4bR0.png)
![Updated homepage Landing Stats](https://i.imgur.com/NO0p7oe.png)
### Checklist
- [ x ] This PR passes Linting tests (see below)
- [ x ] This PR does not contain merge conflicts with `develop` (see below)
- [ x ] This PR does not contain:
  - Additional Dependencies in `package.json` that are not used
  - Frontend JS in Jade templates (unless absolutely necessary)
