### PR TITLE
Feature/footer update

### DIFF
--- a/themes/codeforpoland/public/css/views/contact.scss
+++ b/themes/codeforpoland/public/css/views/contact.scss
@@ -1,3 +1,6 @@
 [data-view='contact'] {
-
+  .contacts
+  {
+    margin-top: 2em;
+  }
 }

--- a/themes/codeforpoland/views/contact/index.jade
+++ b/themes/codeforpoland/views/contact/index.jade
@@ -4,7 +4,7 @@ block content
   .row.breadcrumbs
     .col-sm-12
       a(href='/')= brigade.name
-      | &nbsp;&nbsp;/&nbsp; 
+      | &nbsp;&nbsp;/&nbsp;
       a(href='/contact') Contact
   .row.page-header
     .col-sm-12
@@ -15,7 +15,7 @@ block content
     .col-sm-9
       .row
       each user in users
-        .col-sm-6
+        .col-sm-6.contacts
           .row
             .col-sm-3
                 img(src="#{user.profile.picture}", width='80')
@@ -27,17 +27,17 @@ block content
               if user.profile.position
                 p #{user.profile.position}
               else
-                p position placeholder
+                p #{brigade.name} Member
               if (user.profile.showcontact && user.email)
                 p
                   a(href="mailto: #{user.email}") email
-    .col-sm-3
-      h2 See Also
-      img(src="http://lorempixel.com/g/240/240/")
-      p
-        a(href="#") Visualization Budget Lodz
-      p We visualize the budget of the city of Lodz
-      img(src="http://lorempixel.com/g/240/240/")
+    //- .col-sm-3
+    //-   h2 See Also
+    //-   img(src="http://lorempixel.com/g/240/240/")
+    //-   p
+    //-     a(href="#") Visualization Budget Lodz
+    //-   p We visualize the budget of the city of Lodz
+    //-   img(src="http://lorempixel.com/g/240/240/")
   hr
   .row
     h5.text-xs-center Send a message to the brigade:

--- a/themes/codeforpoland/views/partials/footer.jade
+++ b/themes/codeforpoland/views/partials/footer.jade
@@ -17,7 +17,7 @@ footer
     .col-sm-12
       ul
         li#menu-item-385.menu-item.menu-item-type-post_type.menu-item-object-page.menu-item-385
-          a(href='http://codeforpoland.org/')=brigade.name
+          a(href=brigade.url)=brigade.name
         if brigade.theme.page.events
           li
             a(href='/events') Events


### PR DESCRIPTION
### Description

Fixes brigade footer link to direct to the brigade and not Code for Poland. Reformats the contact page to default the brigade contact to member of the brigade, and removes see also side column.
#### Removed

See Also side column from Contact page.
#### Fixed
- Footer link to direct back to brigade
#### Changed
- Default contact member position to member of brigade.
### Checklist
- [ x ] This PR passes Linting tests (see below)
- [ x ] This PR does not contain merge conflicts with `develop` (see below)
- [ x ] This PR does not contain:
  - Additional Dependencies in `package.json` that are not used
  - Frontend JS in Jade templates (unless absolutely necessary)
